### PR TITLE
fix: analyze job infinite loop

### DIFF
--- a/lib/active_storage/service/ftp_service.rb
+++ b/lib/active_storage/service/ftp_service.rb
@@ -31,7 +31,7 @@ module ActiveStorage
     def download(key)
       if block_given?
         instrument :streaming_download, key: key do
-          open(http_url_for(key)) do |file|
+          URI.open(http_url_for(key)) do |file|
             while data = file.read(64.kilobytes)
               yield data
             end
@@ -39,7 +39,7 @@ module ActiveStorage
         end
       else
         instrument :download, key: key do
-          open(http_url_for(key)) do |file|
+          URI.open(http_url_for(key)) do |file|
             file.read
           end
         end
@@ -48,7 +48,7 @@ module ActiveStorage
 
     def download_chunk(key, range)
       instrument :download_chunk, key: key, range: range do
-        open(http_url_for(key)) do |file|
+        URI.open(http_url_for(key)) do |file|
             file.seek range.begin
             file.read range.size
         end


### PR DESCRIPTION
When the `ActiveStorage::AnalyzeJob` is performed there is an an infinite loop. The following log fragment is repeated over and over again.

```sh
/Users/enrique.arias/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/bundler/gems/activestorage-ftp-821677092442/lib/active_storage/service/ftp_service.rb:34:in `block in download'
/Users/enrique.arias/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.1.3.4/lib/active_support/notifications.rb:206:in `block in instrument'
/Users/enrique.arias/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.1.3.4/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
/Users/enrique.arias/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.1.3.4/lib/active_support/notifications.rb:206:in `instrument'
/Users/enrique.arias/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activestorage-7.1.3.4/lib/active_storage/service.rb:165:in `instrument'
/Users/enrique.arias/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/bundler/gems/activestorage-ftp-821677092442/lib/active_storage/service/ftp_service.rb:33:in `download'
/Users/enrique.arias/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activestorage-7.1.3.4/lib/active_storage/downloader.rb:32:in `download'
/Users/enrique.arias/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activestorage-7.1.3.4/lib/active_storage/downloader.rb:13:in `block in open'
/Users/enrique.arias/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activestorage-7.1.3.4/lib/active_storage/downloader.rb:24:in `open_tempfile'
/Users/enrique.arias/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activestorage-7.1.3.4/lib/active_storage/downloader.rb:12:in `open'
/Users/enrique.arias/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activestorage-7.1.3.4/lib/active_storage/service.rb:92:in `open'
```
The issue happens when the [`ActiveStorage::Service::FtpService#download`](https://github.com/gordienko/activestorage-ftp/blob/8216770924424eeb9afa8d72b7dc0d8ac5f40b59/lib/active_storage/service/ftp_service.rb#L34) method is invoked.

The `ActiveStorage::Service::FtpService#download` method is calling the [`ActiveStorage::Service#open`](https://github.com/rails/rails/blob/b291408f93817235ed8bb19e910716b31610cd19/activestorage/lib/active_storage/service.rb#L91) which is inherited from its parent class (`ActiveStorage::Service`). In turn, the `ActiveStorage::Service#open` method calls the [`ActiveStorage::Downloader#open`](https://github.com/rails/rails/blob/b291408f93817235ed8bb19e910716b31610cd19/activestorage/lib/active_storage/downloader.rb#L11) method which calls the `ActiveStorage::Service::FtpService#download` in the [line 32](https://github.com/rails/rails/blob/b291408f93817235ed8bb19e910716b31610cd19/activestorage/lib/active_storage/downloader.rb#L32) and start all over again.

The error can be easily fixed by prefixing the module `URI` in the `open` method of the FtpService class: `URI.open`..